### PR TITLE
24 Add start values

### DIFF
--- a/.github/workflows/buil_branches.yml
+++ b/.github/workflows/buil_branches.yml
@@ -26,13 +26,22 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-          cache: "pip"
+
+      - name: Restore cached virtualenv
+        uses: actions/cache/restore@v4
+        with:
+          key: venv-${{ runner.os }}-${{ matrix.python-version }}
+          path: .venv
 
       - name: Install dependencies
         run: |
+          python -m venv .venv
+          source .venv/bin/activate
           python -m pip install --upgrade pip
           pip install numpy pandas onnx jinja2 loguru typer fmpy cmake
           pip install -e .
+          echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
+          echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
 
       - name: Python unit tests
         run: |
@@ -51,6 +60,12 @@ jobs:
           target `
           --fmi-platform $fmi_platform `
           --cmake-config Debug
+
+      - name: Save cached virtualenv
+        uses: actions/cache/save@v4
+        with:
+          key: venv-${{ runner.os }}-${{ matrix.python-version }}
+          path: .venv
 
   build_and_test_linux:
     strategy:
@@ -73,7 +88,7 @@ jobs:
       - name: Restore cached virtualenv
         uses: actions/cache/restore@v4
         with:
-          key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+          key: venv-${{ runner.os }}-${{ matrix.python-version }}
           path: .venv
 
       - name: Install dependencies

--- a/.github/workflows/buil_branches.yml
+++ b/.github/workflows/buil_branches.yml
@@ -70,11 +70,21 @@ jobs:
           python-version: ${{ matrix.python-version }}
           cache: "pip"
 
+      - name: Restore cached virtualenv
+        uses: actions/cache/restore@v4
+        with:
+          key: venv-${{ runner.os }}-${{ matrix.python-version }}-${{ hashFiles('requirements.txt') }}
+          path: .venv
+
       - name: Install dependencies
         run: |
+          python -m venv .venv
+          source .venv/bin/activate
           python -m pip install --upgrade pip
           pip install numpy pandas onnx jinja2 loguru typer fmpy cmake
           pip install -e .
+          echo "$VIRTUAL_ENV/bin" >> $GITHUB_PATH
+          echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> $GITHUB_ENV
 
       - name: Python unit tests
         run: |
@@ -92,3 +102,9 @@ jobs:
           target \
           --fmi-platform ${{ matrix.arch }}-${{ matrix.os }} \
           --cmake-config Debug
+
+      - name: Save cached virtualenv
+        uses: actions/cache/save@v4
+        with:
+          key: venv-${{ runner.os }}-${{ matrix.python-version }}
+          path: .venv

--- a/.github/workflows/buil_branches.yml
+++ b/.github/workflows/buil_branches.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m venv .venv
-          source .venv/bin/activate
+          .venv\Scripts\activate
           python -m pip install --upgrade pip
           pip install numpy pandas onnx jinja2 loguru typer fmpy cmake
           pip install -e .

--- a/onnx2fmu/model.py
+++ b/onnx2fmu/model.py
@@ -26,7 +26,7 @@ class Model:
                  fmiVersion: Optional[str] = "2.0",
                  description: Optional[str] = "",
                  ) -> None:
-        self.setName(name)
+        self._setName(name)
         self.fmiVersion = fmiVersion
         self.description = description
         self.vr_generator = (i for i in range(1, 2**32))
@@ -35,7 +35,7 @@ class Model:
         self.outputs = []
         self.locals = []
 
-    def setName(self, name: str) -> None:
+    def _setName(self, name: str) -> None:
         self.name = re.sub(r'[^a-zA-Z0-9]', '', name)
 
     def _assignValueReferences(self, context: dict) -> dict:

--- a/onnx2fmu/template/FMI2.xml
+++ b/onnx2fmu/template/FMI2.xml
@@ -33,7 +33,7 @@
     {%- for input in inputs %}
     {%- for scalar in input.scalarValues %}
     <ScalarVariable name="{{ scalar.name }}" valueReference="{{ scalar.valueReference }}" causality="{{ input.causality }}" variability="{{ input.variability }}" description="{%if scalar.label %}{{ scalar.label }}{% else %}{{ input.description }}{% endif %}">
-      <{{ input.vType.FMIType }} {% if input.start %}start="{{ input.start }}"{% endif %}/>
+      <{{ input.vType.FMIType }} start="{{ scalar.start }}"/>
     </ScalarVariable>
     {%- endfor %}
     {%- endfor %}
@@ -47,7 +47,7 @@
     {%- for local in locals %}
     {%- for scalar in local.scalarValues %}
     <ScalarVariable name="{{ scalar.name }}" valueReference="{{ scalar.valueReference }}" causality="{{ local.causality }}" variability="{{ local.variability }}" description="{%if scalar.label %}{{ scalar.label }}{% else %}{{ local.description }}{% endif %}" initial="{{ local.initial }}">
-      <{{ local.vType.FMIType }} {% if local.start %}start="{{ local.start }}"{% endif %}/>
+      <{{ local.vType.FMIType }} start="{{ scalar.start }}"/>
     </ScalarVariable>
     {%- endfor %}
     {%- endfor %}

--- a/onnx2fmu/template/FMI3.xml
+++ b/onnx2fmu/template/FMI3.xml
@@ -27,7 +27,7 @@
     <Float64 name="time" valueReference="0" causality="independent" variability="continuous" description="Simulation time"/>
     {%- for input in inputs %}
     {%- for scalar in input.scalarValues %}
-    <{{ input.vType.FMIType }} name="{{ scalar.name }}" valueReference="{{ scalar.valueReference }}" causality="{{ input.causality }}" variability="{{ input.variability }}" description="{%if scalar.label %}{{ scalar.label }}{% else %}{{ input.description }}{% endif %}" start="{{ input.start }}"/>
+    <{{ input.vType.FMIType }} name="{{ scalar.name }}" valueReference="{{ scalar.valueReference }}" causality="{{ input.causality }}" variability="{{ input.variability }}" description="{%if scalar.label %}{{ scalar.label }}{% else %}{{ input.description }}{% endif %}" start="{{ scalar.start }}"/>
     {%- endfor %}
     {%- endfor %}
     {%- for output in outputs %}
@@ -37,7 +37,7 @@
     {%- endfor %}
     {%- for local in locals %}
     {%- for scalar in local.scalarValues %}
-    <{{ local.vType.FMIType }} name="{{ scalar.name }}" valueReference="{{ scalar.valueReference }}" causality="{{ local.causality }}" variability="{{ local.variability }}" description="{%if scalar.label %}{{ scalar.label }}{% else %}{{ local.description }}{% endif %}"/>
+    <{{ local.vType.FMIType }} name="{{ scalar.name }}" valueReference="{{ scalar.valueReference }}" causality="{{ local.causality }}" variability="{{ local.variability }}" description="{%if scalar.label %}{{ scalar.label }}{% else %}{{ local.description }}{% endif %}" start="{{ scalar.start }}"/>
     {%- endfor %}
     {%- endfor %}
   </ModelVariables>

--- a/onnx2fmu/template/model.c
+++ b/onnx2fmu/template/model.c
@@ -26,7 +26,18 @@
     } while (0);
 
 void setStartValues(ModelInstance *comp) {
-    UNUSED(comp);
+    // Input variables
+    {%- for input in inputs %}
+    {%- for scalar in input.scalarValues %}
+    M({{ scalar.name }}) = {{ scalar.start }};
+    {%- endfor %}
+    {%- endfor %}
+    // Local variables
+    {%- for local in locals %}
+    {%- for scalar in local.scalarValues %}
+    M({{ scalar.name }}) = {{ scalar.start }};
+    {%- endfor %}
+    {%- endfor %}
 }
 
 Status calculateValues(ModelInstance *comp) {

--- a/tests/example4/example4Description.json
+++ b/tests/example4/example4Description.json
@@ -18,12 +18,20 @@
         {
             "nameIn": "X",
             "nameOut": "X1",
-            "description": "The history of states from t-N to t."
+            "description": "The history of states from t-N to t.",
+            "start": 2.0
         },
         {
             "nameIn": "U",
             "nameOut": "U1",
-            "description": "The history of control variables frmo t-N to t-1."
+            "description": "The history of control variables frmo t-N to t-1.",
+            "start": [
+                10,
+                1.5,
+                0.5,
+                0.1,
+                0.05
+            ]
         }
     ]
 }

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -52,7 +52,8 @@ class TestVariablesFactory(unittest.TestCase):
             "variability": "continuous",
             "fmiVersion": "2.0",
             "vType": FMI2TYPES[TensorProto.FLOAT],
-            "scalarValues": [{"name": "x_0", "label": ""}],
+            "scalarValues": [{"name": "x_0", "label": "", "start": "1.0"}],
+            "start": "1.0"
         }
         for k in v.generateContext():
             self.assertEqual(context[k], getattr(v, k))
@@ -61,7 +62,7 @@ class TestVariablesFactory(unittest.TestCase):
 class TestInputVariable(unittest.TestCase):
 
     def test_print(self):
-        v = Input(name="x", start=2.0)
+        v = Input(name="x", start="2.0")
         self.assertEqual(
             "Input(x, continuous)(2.0)",
             v.__str__()


### PR DESCRIPTION
Start values for variables can be provided in the model description. They can be either a scalar, a vector, or an array. In the case of a scalar, all array elements will be equal to the scalar value. In the case of 1D arrays, these must be broadcastable to larger-dimensional arrays to create a "steady-state" start value for that variable.