### PR TITLE
Onnxruntime version selection

### DIFF
--- a/onnx2fmu/CMakeLists.txt
+++ b/onnx2fmu/CMakeLists.txt
@@ -125,7 +125,7 @@ SET(SOURCES
 )
 
 # Manually set the latest release tag
-set (LATEST_RELEASE_TAG "1.20.1")
+set (LATEST_RELEASE_TAG "1.20.1" CACHE STRING "Latest ONNX Runtime release tag to download")
 
 # Detect the operating system for onnxruntime download
 if (WIN32)

--- a/onnx2fmu/app.py
+++ b/onnx2fmu/app.py
@@ -207,6 +207,10 @@ def compile(
         '-D', f'FMI_VERSION={int(float(model_description["FMIVersion"]))}',
     ]
 
+    onnx_runtime_version = model_description.get("onnxRuntimeVersion", None)
+    if onnx_runtime_version:
+        cmake_args += ['-D', f'LATEST_RELEASE_TAG={onnx_runtime_version}']
+
     if fmi_architecture:
         cmake_args += ['-D', f'FMI_ARCHITECTURE={fmi_architecture}']
 

--- a/onnx2fmu/src/cosimulation.c
+++ b/onnx2fmu/src/cosimulation.c
@@ -108,6 +108,11 @@ ModelInstance *createModelInstance(
 
     // Load the model
     initializeOrtApi(comp);
+    if (!comp->g_ort) {
+        logError(comp, "Failed to initialize ONNX Runtime API.");
+        freeModelInstance(comp);
+        return NULL;
+    }
     createOrtEnv(comp);
     createOrtSessionOptions(comp);
     createOrtSession(comp->env, resourceLocation, comp->session_options, comp);

--- a/onnx2fmu/src/ortUtils.c
+++ b/onnx2fmu/src/ortUtils.c
@@ -19,7 +19,8 @@ void initializeOrtApi(ModelInstance* comp) {
     const OrtApi* g_ort = NULL;
     g_ort = OrtGetApiBase()->GetApi(ORT_API_VERSION);
     if (!g_ort) {
-        logError(comp, "Failed to init ONNX Runtime engine.");
+        const char *version = OrtGetApiBase()->GetVersionString();
+        logError(comp, "Failed to init ONNX Runtime engine: get '%s' instead of '%d'", version, ORT_API_VERSION);
         return;
     }
     comp->g_ort = g_ort;


### PR DESCRIPTION
In some cases, fmi-importer already loaded ONNX Runtime. This PR allows the user to specify the ORT version to use through `.json` file:


```
...
  "onnxRuntimeVersion": "1.17.1",
...
```