### PR TITLE
Update ONNX Runtime to 1.21.0

### DIFF
--- a/onnx2fmu/CMakeLists.txt
+++ b/onnx2fmu/CMakeLists.txt
@@ -125,7 +125,7 @@ SET(SOURCES
 )
 
 # Manually set the latest release tag
-set (LATEST_RELEASE_TAG "1.20.1")
+set (LATEST_RELEASE_TAG "1.21.0")
 
 # Detect the operating system for onnxruntime download
 if (WIN32)


### PR DESCRIPTION
## Summary

- Bumps `LATEST_RELEASE_TAG` in `onnx2fmu/CMakeLists.txt` from `1.20.1` to `1.21.0`

## Test plan

- [x] All 16 pure-Python unit tests pass (`test_variables`, `test_model`, `test_model_description`)
- [x] All compile tests pass for FMI 2 and FMI 3 across examples 1–4 (onnxruntime 1.21.0 downloaded and linked successfully)

🤖 Generated with [Claude Code](https://claude.com/claude-code)