### PR TITLE
Fix test_compile_and_simulate calling renamed method

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -139,7 +139,7 @@ class TestExample1(unittest.TestCase):
         self.assertEqual(len(results), 0, results)
 
     def test_compile_and_simulate(self):
-        self.test_compile()
+        self.test_compile_fmi2()
         # Read input data
         signals = np.genfromtxt(self.base_dir / "Example1_in.csv",
                                 delimiter=",", names=True)


### PR DESCRIPTION
## Summary
- `TestExample1.test_compile_and_simulate` was calling `self.test_compile()`, which no longer exists after the method was renamed to `test_compile_fmi2`
- One-line fix: update the call to `self.test_compile_fmi2()`

## Test plan
- [x] `uv run python -m unittest tests.test_app.TestExample1.test_compile_and_simulate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)