### PR TITLE
Fix silent empty ORT archive when download is blocked by firewall

### DIFF
--- a/onnx2fmu/CMakeLists.txt
+++ b/onnx2fmu/CMakeLists.txt
@@ -179,6 +179,23 @@ else ()
     message(STATUS "ONNX Runtime archive already exists at ${ONNXRUNTIME_ARCHIVE_PATH}")
 endif ()
 
+# A firewall or proxy may silently produce a zero-byte file instead of the real archive.
+# Detect this early, remove the empty file (so the next run re-downloads), and give
+# the user actionable instructions.
+file(SIZE ${ONNXRUNTIME_ARCHIVE_PATH} ONNXRUNTIME_ARCHIVE_SIZE)
+if (ONNXRUNTIME_ARCHIVE_SIZE EQUAL 0)
+    file(REMOVE ${ONNXRUNTIME_ARCHIVE_PATH})
+    message(FATAL_ERROR
+        "ONNX Runtime archive is empty (0 bytes): ${ONNXRUNTIME_ARCHIVE_PATH}\n"
+        "This is usually caused by a firewall or proxy blocking the download.\n"
+        "Please download the archive manually from:\n"
+        "  ${ONNXRUNTIME_URL}\n"
+        "save it to:\n"
+        "  ${ONNXRUNTIME_ARCHIVE_PATH}\n"
+        "and re-run CMake."
+    )
+endif ()
+
 # Extract the ONNX Runtime release
 execute_process(
     COMMAND ${CMAKE_COMMAND} -E tar xzf ${ONNXRUNTIME_ARCHIVE_PATH}
@@ -189,7 +206,15 @@ execute_process(
 if (EXISTS "${CMAKE_CURRENT_BINARY_DIR}/${ONNXRUNTIME}/include/onnxruntime_c_api.h")
   message(STATUS "ONNX Runtime extraction successful.")
 else ()
-  message(FATAL_ERROR "ONNX Runtime extraction failed. File not found: ${CMAKE_CURRENT_BINARY_DIR}/${ONNXRUNTIME}/include/onnxruntime_c_api.h")
+  message(FATAL_ERROR
+      "ONNX Runtime extraction failed — "
+      "${CMAKE_CURRENT_BINARY_DIR}/${ONNXRUNTIME}/include/onnxruntime_c_api.h not found.\n"
+      "The archive at ${ONNXRUNTIME_ARCHIVE_PATH} may be corrupt or incomplete.\n"
+      "Delete it and re-run CMake, or download manually from:\n"
+      "  ${ONNXRUNTIME_URL}\n"
+      "and save to:\n"
+      "  ${ONNXRUNTIME_ARCHIVE_PATH}"
+  )
 endif ()
 
 # Include the onnxruntime directory like in https://github.com/microsoft/onnxruntime-inference-examples/blob/main/c_cxx/CMakeLists.txt


### PR DESCRIPTION
## Summary

- Detects a zero-byte ONNX Runtime archive left behind when a corporate firewall silently intercepts the download
- Removes the empty file so the next `cmake` run will attempt a fresh download instead of getting stuck
- Emits a `FATAL_ERROR` with the likely cause (firewall/proxy) and exact manual-download URL + cache path
- Improves the extraction-failure error message with the same actionable guidance

Closes #35

## Test plan

- [ ] **Happy path**: run `onnx2fmu build` with network access — build completes as before
- [ ] **Empty-file path**: place a zero-byte file at the ORT cache path, re-run CMake — new `FATAL_ERROR` appears with the download URL, and the empty file is deleted
- [ ] **Corrupt-archive path**: place a non-archive file at the cache path — extraction fails with the improved message pointing to the manual-download URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)