### PR TITLE
Add Python 3.13 support

### DIFF
--- a/.github/workflows/buil_branches.yml
+++ b/.github/workflows/buil_branches.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         arch: [x86_64]
         os: [windows]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     runs-on: [self-hosted, Windows]
 
     steps:
@@ -92,7 +92,7 @@ jobs:
       matrix:
         arch: [x86_64]
         os: [linux]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     runs-on: [self-hosted, Linux]
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,22 @@ jobs:
             image: macos-15
             arch: aarch64
             python-version: "3.10"
+          - name: x86-windows-py313
+            image: windows-2022
+            arch: x86
+            python-version: "3.13"
+          - name: x86_64-windows-py313
+            image: windows-2022
+            arch: x86_64
+            python-version: "3.13"
+          - name: x86_64-linux-py313
+            image: ubuntu-22.04
+            arch: x86_64
+            python-version: "3.13"
+          - name: aarch64-darwin-py313
+            image: macos-15
+            arch: aarch64
+            python-version: "3.13"
     runs-on: ${{ matrix.image }}
 
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 	  "Development Status :: 4 - Beta",

--- a/uv.lock
+++ b/uv.lock
@@ -1115,7 +1115,7 @@ wheels = [
 
 [[package]]
 name = "onnx2fmu"
-version = "0.3.1"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "cmake" },


### PR DESCRIPTION
Extend CI matrices and PyPI classifiers to include Python 3.13. No source or dependency changes required — all current packages already ship cp313 wheels and uv.lock already contains 3.13 resolution markers.